### PR TITLE
HW 2. Kubernetes Controllers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .idea/
 .editorconfig
+kubernetes-controllers/kind-config.yaml

--- a/README.md
+++ b/README.md
@@ -1,10 +1,34 @@
 # ifqthenp_platform
+
 ifqthenp Platform repository
 
 ## HW 1. Kubernetes Intro
 
 - Created Docker image with simple http server using `kubernetes-intro/web/Dockerfile` file
 - Created Kubernetes manifest file describing Pod with `containers` and `initContainer` specs
-- Fixed broken `frontend` Pod from [Hipster Shop repo][1] and saved result in `kubernetes-intro/frontend-pod-healthy.yaml`
+- :star: Fixed broken `frontend` Pod from [Hipster Shop repo][1] and saved result in `kubernetes-intro/frontend-pod-healthy.yaml`
 
 [1]: https://github.com/GoogleCloudPlatform/microservices-demo
+
+## HW 2. Kubernetes Controllers
+
+- Launched Kubernetes cluster using [Kind][1] tool
+- Created ReplicaSet resource for the `frontend` microservice
+- Changed the number of replicas using ad-hoc command `kubectl scale replicaset frontend --replicas=3`
+- Updated pod template in the `frontend` ReplicaSet to use different docker image:
+  - `export KUBE_EDITOR="/usr/local/bin/code"`
+  - `kubectl edit rs frontend` (change image tag either to `v0.0.1` or `v.0.0.2`)
+  - `kubectl get replicaset frontend -o=jsonpath='{.spec.template.spec.containers[0].image}'`
+  - `kubectl get pods -l app=frontend -o=jsonpath='{.items[0:3].spec.containers[0].image}'`
+  - alternatively, make changes in `frontend-replicaset.yaml` file and re-apply it with `kubectl apply -f frontend-replicaset.yaml`
+- Created ReplicaSet and Deployment resources for the `payment` microservice
+- :star: Used `maxSurge` and `maxUnavailable` parameters in `payment` microservice to create deployment strategies similar to **Blue/Green** and **Reverse Rolling Update**
+- Added pod readiness probes to `frontend` microservice:
+  - `kubectl rollout status deployment/frontend --timeout=60s`
+  - `kubectl rollout undo deployment/frontend` (in case of readiness probe failure)
+- :star::star: Created manifest `node-exporter-daemonset.yaml` configured to collect hardware and OS metrics for both worker and master nodes using [Node Exporter][2]:
+  - `kubectl port-forward <POD_NAME> 9100:9100`
+  - `curl localhost:9100/metrics`
+
+[1]: https://kind.sigs.k8s.io/docs/user/quick-start
+[2]: https://github.com/prometheus/node_exporter

--- a/kubernetes-controllers/frontend-deployment.yaml
+++ b/kubernetes-controllers/frontend-deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: server
+          image: ifqthenp/hipster-shop-frontend:v0.0.1
+          readinessProbe:
+            initialDelaySeconds: 10
+            httpGet:
+              port: 8080
+              path: "/_healthz"
+              httpHeaders:
+                - name: "Cookie"
+                  value: "shop_session-id=x-readiness-probe"
+          env:
+            - name: PORT
+              value: "8080"
+            - name: PRODUCT_CATALOG_SERVICE_ADDR
+              value: "productcatalogservice:3550"
+            - name: CURRENCY_SERVICE_ADDR
+              value: "currencyservice:7000"
+            - name: CART_SERVICE_ADDR
+              value: "cartservice:7070"
+            - name: RECOMMENDATION_SERVICE_ADDR
+              value: "recommendationservice:8080"
+            - name: SHIPPING_SERVICE_ADDR
+              value: "shippingservice:50051"
+            - name: CHECKOUT_SERVICE_ADDR
+              value: "checkoutservice:5050"
+            - name: AD_SERVICE_ADDR
+              value: "adservice:9555"

--- a/kubernetes-controllers/frontend-replicaset.yaml
+++ b/kubernetes-controllers/frontend-replicaset.yaml
@@ -1,0 +1,36 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: frontend
+  labels:
+    app: frontend
+spec:
+  selector:
+    matchLabels:
+      app: frontend
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: frontend
+    spec:
+      containers:
+        - name: frontend
+          image: ifqthenp/hipster-shop-frontend:v0.0.1
+          env:
+            - name: PORT
+              value: "8080"
+            - name: PRODUCT_CATALOG_SERVICE_ADDR
+              value: "productcatalogservice:3550"
+            - name: CURRENCY_SERVICE_ADDR
+              value: "currencyservice:7000"
+            - name: CART_SERVICE_ADDR
+              value: "cartservice:7070"
+            - name: RECOMMENDATION_SERVICE_ADDR
+              value: "recommendationservice:8080"
+            - name: SHIPPING_SERVICE_ADDR
+              value: "shippingservice:50051"
+            - name: CHECKOUT_SERVICE_ADDR
+              value: "checkoutservice:5050"
+            - name: AD_SERVICE_ADDR
+              value: "adservice:9555"

--- a/kubernetes-controllers/node-exporter-daemonset.yaml
+++ b/kubernetes-controllers/node-exporter-daemonset.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: node-exporter-prom-ds
+  labels:
+    app: node-exporter-prom
+spec:
+  selector:
+    matchLabels:
+      app: node-exporter-prom-ds
+  template:
+    metadata:
+      labels:
+        app: node-exporter-prom-ds
+    spec:
+      tolerations:
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+      containers:
+        - name: node-exporter-prom-ds
+          image: prom/node-exporter:v0.18.1

--- a/kubernetes-controllers/paymentservice-deployment-bg.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-bg.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  selector:
+    matchLabels:
+      app: paymentservice
+  strategy:
+    rollingUpdate:
+      maxSurge: 100%
+      maxUnavailable: 0
+    type: RollingUpdate
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: paymentservice
+          image: ifqthenp/hipster-shop-paymentservice:v0.0.2

--- a/kubernetes-controllers/paymentservice-deployment-reverse.yaml
+++ b/kubernetes-controllers/paymentservice-deployment-reverse.yaml
@@ -1,0 +1,24 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  selector:
+    matchLabels:
+      app: paymentservice
+  strategy:
+    rollingUpdate:
+      maxSurge: 0
+      maxUnavailable: 1
+    type: RollingUpdate
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: paymentservice
+          image: ifqthenp/hipster-shop-paymentservice:v0.0.1

--- a/kubernetes-controllers/paymentservice-deployment.yaml
+++ b/kubernetes-controllers/paymentservice-deployment.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  selector:
+    matchLabels:
+      app: paymentservice
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: paymentservice
+          image: ifqthenp/hipster-shop-paymentservice:v0.0.1

--- a/kubernetes-controllers/paymentservice-replicaset.yaml
+++ b/kubernetes-controllers/paymentservice-replicaset.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: paymentservice
+  labels:
+    app: paymentservice
+spec:
+  selector:
+    matchLabels:
+      app: paymentservice
+  replicas: 3
+  template:
+    metadata:
+      labels:
+        app: paymentservice
+    spec:
+      containers:
+        - name: paymentservice
+          image: ifqthenp/hipster-shop-paymentservice:v0.0.1


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [x] Основное ДЗ
 - [x] Задание со *

## В процессе сделано:

- Найдена причина по которой обновление шаблона Pod в ReplicaSet не влечет за собой обновление уже запущенных Pod-ов. Об этом можно прочитать в [документации Kubernetes][1]:
  - _"The ReplicationController simply ensures that the desired number of pods matches its label selector and are operational..."_
  - _"...The ReplicationController is forever constrained to this narrow responsibility..."_
  - _"...Nor should it verify that the pods controlled match the currently specified template..."_
- Launched Kubernetes cluster using Kind tool
- Created ReplicaSet resource for the `frontend` microservice
- Changed the number of replicas using ad-hoc command `kubectl scale replicaset frontend --replicas=3`
- Updated pod template in the `frontend` ReplicaSet to use different docker image
- Created ReplicaSet and Deployment resources for the `payment` microservice
- :star: Used `maxSurge` and `maxUnavailable` parameters in `payment` microservice to create deployment strategies similar to **Blue/Green** and **Reverse Rolling Update**
- Added pod readiness probes to `frontend` microservice
- :star::star: Created manifest `node-exporter-daemonset.yaml` configured to collect hardware and OS metrics for both worker and master nodes using Node Exporter

[1]: https://kubernetes.io/docs/concepts/workloads/controllers/replicationcontroller/#writing-programs-for-replication

## Как запустить проект:
 
Apply one of the manifests from `kubernetes-controllers` folder using `kubernetes apply -f FILE_NAME`

## Как проверить работоспособность:

Run `kubectl get all` and see if appropriate Kubernetes resources are running.

For the task with DaemonSet and Node Exporter, run

```
kubectl apply -f node-exporter-daemonset.yaml
kubectl get po -o wide
```
The output should look similar to this:

```
NAME                          READY   STATUS    RESTARTS   AGE   IP           NODE                  NOMINATED NODE   READINESS GATES
node-exporter-prom-ds-6dtd2   1/1     Running   0          58m   10.244.5.5   kind-worker3          <none>           <none>
node-exporter-prom-ds-79f6g   1/1     Running   0          58m   10.244.2.2   kind-control-plane3   <none>           <none>
node-exporter-prom-ds-7wmsx   1/1     Running   0          58m   10.244.0.4   kind-control-plane    <none>           <none>
node-exporter-prom-ds-8qjzz   1/1     Running   0          58m   10.244.3.3   kind-worker           <none>           <none>
node-exporter-prom-ds-khpp6   1/1     Running   0          58m   10.244.4.5   kind-worker2          <none>           <none>
node-exporter-prom-ds-t2vx4   1/1     Running   0          58m   10.244.1.2   kind-control-plane2   <none>           <none>
```

To check that metrics are being collected, run

```
kubectl port-forward DS_POD_NAME 9100:9100
curl localhost:9100/metrics
```

## PR checklist:
 - [x] Выставлен label с номером домашнего задания
